### PR TITLE
Skip 2FA check for users who require email verification

### DIFF
--- a/resources/blueprints/settings.yaml
+++ b/resources/blueprints/settings.yaml
@@ -28,6 +28,17 @@ tabs:
                 - key: off
                   value: Off
           -
+            handle: alt_google_2fa_unverified_user_no_redirect
+            field:
+              type: toggle
+              display: 'Disable redirect for users who have not verified their email address'
+              instructions_position: above
+              listable: hidden
+              visibility: visible
+              replicator_preview: true
+              antlers: false
+              hide_display: false
+          -
             handle: alt_google_2fa_forced_roles
             field:
               type: user_roles

--- a/src/Http/Middleware/CheckFor2FA.php
+++ b/src/Http/Middleware/CheckFor2FA.php
@@ -3,6 +3,7 @@
 namespace AltDesign\AltGoogle2FA\Http\Middleware;
 
 use Closure;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -30,6 +31,12 @@ class CheckFor2FA
         $superUserPolicy = $data->data['alt_google_2fa_forced_super_user'] ?? 'off';
         $forcedRoles = $data->data['alt_google_2fa_forced_roles'] ?? [];
         $optionalRoles = $data->data['alt_google_2fa_optional_roles'] ?? [];
+
+        // If user's email requires verification, skip this until they're verified
+        $authUser = Auth::user();
+        if ($authUser instanceof MustVerifyEmail && !$authUser->verified) {
+            return $next($request);
+        }
 
         // Skip checking 2FA for routes related to 2FA (to prevent infinite loops)
         if ($request->routeIs('alt-google-2fa.prompt', 'alt-google-2fa.enable-2fa', 'alt-google-2fa.verify', 'statamic.logout')) {

--- a/src/Http/Middleware/CheckFor2FA.php
+++ b/src/Http/Middleware/CheckFor2FA.php
@@ -31,11 +31,14 @@ class CheckFor2FA
         $superUserPolicy = $data->data['alt_google_2fa_forced_super_user'] ?? 'off';
         $forcedRoles = $data->data['alt_google_2fa_forced_roles'] ?? [];
         $optionalRoles = $data->data['alt_google_2fa_optional_roles'] ?? [];
+        $noRedirectUnverified = $data->data['alt_google_2fa_unverified_user_no_redirect'] ?? false;
 
-        // If user's email requires verification, skip this until they're verified
-        $authUser = Auth::user();
-        if ($authUser instanceof MustVerifyEmail && !$authUser->verified) {
-            return $next($request);
+        if ($noRedirectUnverified) {
+            // If user's email requires verification, skip this until they're verified
+            $authUser = Auth::user();
+            if ($authUser instanceof MustVerifyEmail && !$authUser->hasVerifiedEmail()) {
+                return $next($request);
+            }
         }
 
         // Skip checking 2FA for routes related to 2FA (to prevent infinite loops)


### PR DESCRIPTION
I'm developing a statamic/simple commerce site that is using this and requires verified emails. It's using all of the statamic stuff for doing front-end registration and logging in. 

I'm finding that this is generally going a bit wrong when it comes to activating emails on the FE side. I think this is because the ServiceProvider is going:
```PHP
AuthGuard::class => [
    'alt-google-2fa' => \AltDesign\AltGoogle2FA\Http\Middleware\CheckFor2FA::class
]
```
Causing this to fire in cases where I'm not explicitly adding the middleware to my routes, and it's causing this to be required before verification happens (which is a problem for me as the email verification is a bit complicated due to it needing to redirect you to different places depending on how you signed up). This PR adds a check that, should the user require their email to be verified, it will refuse to redirect you to the 2FA setup screen.

I've added a new config value to turn this behaviour on (defaults to off) to the blueprint for this. It can be toggled in the control panel page.

I'm open to suggestions on how to improve this.