### PR TITLE
Made it possible to publish and edit routes.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -55,6 +55,24 @@ class ServiceProvider extends AddonServiceProvider
         $this->publishes([
             __DIR__ . '/../database/migrations/' => database_path('migrations'),
         ], 'alt-google-2fa-migrations');
+
+        $this->publishes([
+            __DIR__ . '/../routes/cp.php' => base_path('routes/vendor/alt-google-2fa/cp.php'),
+            __DIR__ . '/../routes/web.php' => base_path('routes/vendor/alt-google-2fa/web.php'),
+        ], 'alt-google-2fa-routes');
+    }
+
+    protected function bootRoutes()
+    {
+        $cpPath = base_path('routes/vendor/alt-google-2fa/cp.php');
+        $webPath = base_path('routes/vendor/alt-google-2fa/web.php');
+        if (file_exists($cpPath)) {
+            $this->routes['cp'] = $cpPath;
+        }
+        if (file_exists($webPath)) {
+            $this->routes['web'] = $webPath;
+        }
+        return parent::bootRoutes();
     }
 }
 


### PR DESCRIPTION
I can't actually find any way to edit the URIs of the routes this package uses. This PR is intended to address that.

This allows the projects using this package to publish the package's routes to routes/vendor/alt-google-2fa/ so they can be edited. The changes also make the service provider check for these and use them if present. It should be a case of running this and editing the files it creates:
```
artisan vendor:publish --tag=alt-google-2fa-routes
```

If there's a better way to make these URIs editable, I'm open to suggestions. I can absolutely understand if you don't want to expose these files - I'd imagine there's potential for a maintenance headache if you ever need to add new routes. However, from what I gather the next version of Statamic is going to have 2FA built in, so it probably won't be an issue?

Apologies if this isn't very idiomatic to Laravel - I'm pretty new to using it. I'm absolutely fine with any tweaks to this if you're happy with the core approach or an entirely different approach if you're not.